### PR TITLE
Fix double-escaping issue

### DIFF
--- a/content.js
+++ b/content.js
@@ -19,9 +19,12 @@ function aa(a) {
             fontFamily: c.css("fontFamily"),
             lineHeight: c.css("lineHeight")
         });
-        var b = a.value.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/$/, "&nbsp;").replace(/\n/g,
-                "&nbsp;<br/>").replace(/\s/g, "&nbsp;"),
-            e = b.split("<br/>").length - 1;
+        var b = a.value
+        .replace(/&/g, "&amp;")  
+        .replace(/</g, "&lt;")   
+        .replace(/>/g, "&gt;")   
+        .replace(/ /g, "&nbsp;"),  
+        e = b.split("<br/>").length - 1;
         d.html(b);
         c.css({
             width: d.width() + f + "px"


### PR DESCRIPTION
`### Fix Double-Escaping Issue This pull request addresses the double-escaping issue identified in the code.

 #### Problem The original code snippet was causing certain characters to be escaped multiple times, which could lead to unexpected behavior and potential security vulnerabilities. Specifically, the `&` character was being double-escaped.

 #### Solution To resolve this issue, we have simplified the escaping logic to ensure that each character is only escaped once. The revised code snippet is as follows: 

```javascript 
var b = a.value 
.replace(/&/g, "&amp;")
 .replace(/</g, "&lt;")
 .replace(/>/g, "&gt;")
 .replace(/ /g, "&nbsp;");