### PR TITLE
fix(docs): Update Releases link to absolute URL in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ BLT is a Chrome extension that enables users to take screenshots or capture spec
 
 ### For Google Chrome
 
-1. **Download the Extension**: Download the latest version of BLT from the [Releases](../releases) page on GitHub.
+1. **Download the Extension**: Download the latest version of BLT from the [Releases](https://github.com/OWASP-BLT/BLT-Extension/releases) page on GitHub.
 
 2. **Unzip the File**: After downloading, unzip the file to a directory on your computer.
 


### PR DESCRIPTION
The previous relative URL (../releases) for the Releases page in the `README.md` file resulted in a 404 error. This commit updates the link to an absolute URL (https://github.com/OWASP-BLT/BLT-Extension/releases) to ensure users can access the latest extension downloads without issues.