### PR TITLE
Migrate : ManifestV2  to ManifestV3

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,0 +1,10 @@
+chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
+  if (msg.action === "takeScreenshot") {
+    chrome.tabs.captureVisibleTab(null, { format: "png" }, (dataUrl) => {
+      chrome.downloads.download({
+        url: dataUrl,
+        filename: "screenshot.png"
+      });
+    });
+  }
+});

--- a/manifest.json
+++ b/manifest.json
@@ -1,47 +1,55 @@
 {
-   "author": "OWASP BLT",
-   "background": {
-      "persistent": false,
-      "scripts": [ "libs/jquery-1.11.1.min.js", "event.js" ]
-   },
-   "browser_action": {
-      "default_icon": {
-         "19": "img/icon19.png",
-         "38": "img/icon38.png"
-      },
-      "default_title": "OWASP BLT-Extension",
-      "default_popup": "popup.html"
-   },
-   "content_security_policy": "script-src 'self' https://ssl.google-analytics.com; object-src 'self'",
-   "default_locale": "en",
-   "description": "OWASP BLT let's you get points for testing and finding issues!",
-   "homepage_url": "https://www.owasp.org/BLT/",
-   "icons": {
-      "128": "img/icon128.png",
+  "manifest_version": 3,
+  "name": "OWASP BLT-Extension",
+  "short_name": "BLT-Extension",
+  "version": "1.5",
+  "default_locale": "en",
+  "author": "OWASP BLT",
+  "description": "OWASP BLT lets you get points, track jobs, and manage applications.",
+
+  "icons": {
+    "19": "img/icon19.png",
+    "38": "img/icon38.png",
+    "128": "img/icon128.png"
+  },
+
+  "action": {
+    "default_icon": {
       "19": "img/icon19.png",
-      "24": "img/icon24.png",
-      "256": "img/icon256.png",
-      "32": "img/icon32.png",
       "38": "img/icon38.png"
-   },
-   "manifest_version": 2,
-   "name": "OWASP BLT-Extension",
-   "short_name": "BLT-Extension",
-   "permissions": [ "\u003Call_urls>", "activeTab", "storage", "unlimitedStorage", "notifications", "clipboardWrite", "downloads", "tabCapture" ],
-   "update_url": "https://clients2.google.com/service/update2/crx",
-   "version": "1.4",
-   "web_accessible_resources": [
-      "jobtracking.html",
-      "jobtracking.js"
-   ],
-   "content_scripts": [
-      {
-         "matches": ["*://*.linkedin.com/jobs/*"],
-         "js": ["linkedin-monitor.js"]
-      },
-      {
-         "matches": ["*://*.wellfound.com/jobs*"],
-         "js": ["wellfound-monitor.js"]
-      }
-   ]
+    },
+    "default_title": "OWASP BLT-Extension",
+    "default_popup": "popup.html"
+  },
+  "background": {
+    "service_worker": "background.js"
+  },
+
+  "permissions": ["activeTab", "tabs", "storage", "downloads", "scripting"],
+
+  "host_permissions": ["<all_urls>"],
+
+  "content_scripts": [
+    {
+      "matches": ["*://*.linkedin.com/jobs/*"],
+      "js": ["linkedin-monitor.js"]
+    },
+    {
+      "matches": ["*://*.wellfound.com/jobs*"],
+      "js": ["wellfound-monitor.js"]
+    }
+  ],
+
+  "web_accessible_resources": [
+    {
+      "resources": ["jobtracking.html", "jobtracking.js"],
+      "matches": ["<all_urls>"]
+    }
+  ],
+
+  "content_security_policy": {
+    "extension_pages": "script-src 'self'; object-src 'self'"
+  },
+
+  "homepage_url": "https://www.owasp.org/BLT/"
 }


### PR DESCRIPTION
Since Chrome has deprecated support for Manifest V2 so this PR help migrate to Manifest V3 in order to function and available for users.
Closes #27 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added screenshot capture functionality to download the currently visible browser tab as a PNG image file.

* **Chores**
  * Updated extension manifest to Chrome Manifest Version 3 with revised permissions, service worker background configuration, and updated security policies.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->